### PR TITLE
Docs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,16 @@
+/// # Fantom Libtransport/errors
+///
+/// This file simply defines a set of errors and error handling functionality for the Transport
+/// trait. THis simply allows us to convert any std::Error to a variant as described in libcommon.rs.
+
 use libcommon_rs::errors::Error as BaseError;
 use std::error::Error as StdError;
 use std::sync::{MutexGuard, PoisonError};
 
+/// Standard Error type as defiend by the std library.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// A set of enums to differentiate between different types of errors.
 #[derive(Debug)]
 pub enum Error {
     Base(BaseError),
@@ -15,7 +22,7 @@ pub enum Error {
     Incomplete,
     PoisonError(String),
 }
-
+/// Allow errors to be converted from a standard error to a BaseError type.
 impl From<BaseError> for Error {
     #[inline]
     fn from(be: BaseError) -> Error {
@@ -23,6 +30,7 @@ impl From<BaseError> for Error {
     }
 }
 
+/// Allow errors to be converted from a standard error to a bincode type.
 impl From<bincode::Error> for Error {
     #[inline]
     fn from(bincode_error: bincode::Error) -> Error {
@@ -30,6 +38,7 @@ impl From<bincode::Error> for Error {
     }
 }
 
+/// Allow errors to be converted from a standard error to a io_error type.
 impl From<std::io::Error> for Error {
     #[inline]
     fn from(io_error: std::io::Error) -> Error {
@@ -37,12 +46,14 @@ impl From<std::io::Error> for Error {
     }
 }
 
+/// Allow errors to be converted from a standard error to a PoisonError.
 impl<'a, T> From<PoisonError<MutexGuard<'a, T>>> for Error {
     fn from(e: PoisonError<MutexGuard<'a, T>>) -> Error {
         Error::PoisonError(e.description().to_string())
     }
 }
 
+/// Macro for when there is no error: equivalent of a 'None' for errors.
 #[macro_export]
 macro_rules! none_error {
     () => {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,6 @@
 ///
 /// This file simply defines a set of errors and error handling functionality for the Transport
 /// trait. THis simply allows us to convert any std::Error to a variant as described in libcommon.rs.
-
 use libcommon_rs::errors::Error as BaseError;
 use std::error::Error as StdError;
 use std::sync::{MutexGuard, PoisonError};

--- a/src/generic_test.rs
+++ b/src/generic_test.rs
@@ -4,9 +4,8 @@
 /// Transport trait. This file contains a bunch of dummy data which can be quickly used for any
 /// Transport struct.
 ///
-/// The common_test method allows us to quickly test the new(), send(), and broadcast methods and
+/// The common_test method allows us to quickly test the new(), send(), and broadcast() methods and
 /// (hopefully) verifies that they work.
-
 use crate::errors::{Error, Error::AtMaxVecCapacity};
 use crate::{Transport, TransportConfiguration};
 use core::slice::{Iter, IterMut};
@@ -38,7 +37,8 @@ impl From<usize> for Data {
     }
 }
 
-// A simple struct for holding peer information, This includes both an id and an address.
+// A simple test struct for holding peer information. This includes both an id and an address.
+// NOTE: This specific implementation is only for testing purposes.
 pub struct TestPeer<Id> {
     pub id: Id,
     pub net_addr: String,
@@ -60,7 +60,7 @@ impl Peer<Id> for TestPeer<Id> {
     }
 }
 
-// Creation of our own PeerList type.
+// Creation of our own PeerList type (used for testing purposes)
 pub struct TestPeerList<Id> {
     peers: Vec<TestPeer<Id>>,
 }
@@ -82,7 +82,6 @@ impl<Id> IndexMut<usize> for TestPeerList<Id> {
 
 // Implementation of PeerList for our TestPeerList struct.
 impl PeerList<Id, Error> for TestPeerList<Id> {
-
     type P = TestPeer<Id>;
 
     // Constructor
@@ -91,7 +90,7 @@ impl PeerList<Id, Error> for TestPeerList<Id> {
             peers: Vec::with_capacity(1),
         }
     }
-    // Function which allows addimng new peers to our peer list.
+    // Function which allows adding new peers to our peer list.
     fn add(&mut self, p: TestPeer<Id>) -> std::result::Result<(), Error> {
         // Check if we're at max capacity
         if self.peers.len() == std::usize::MAX {
@@ -107,11 +106,11 @@ impl PeerList<Id, Error> for TestPeerList<Id> {
         // Stub not used in tests to satisfy PeerList trait
         Ok(())
     }
-    // Allows iteration over the file.
+    // Allows iteration over the peer list.
     fn iter(&self) -> Iter<'_, Self::P> {
         self.peers.iter()
     }
-    // Allows a mutable iteration over the file.
+    // Allows a mutable iteration over the peer list.
     fn iter_mut(&mut self) -> IterMut<'_, Self::P> {
         self.peers.iter_mut()
     }

--- a/src/generic_test.rs
+++ b/src/generic_test.rs
@@ -1,3 +1,12 @@
+/// # Fantom Libtransport/generic_tests
+///
+/// This file contains a set of generic tests which can be used to test the functionality of the
+/// Transport trait. This file contains a bunch of dummy data which can be quickly used for any
+/// Transport struct.
+///
+/// The common_test method allows us to quickly test the new(), send(), and broadcast methods and
+/// (hopefully) verifies that they work.
+
 use crate::errors::{Error, Error::AtMaxVecCapacity};
 use crate::{Transport, TransportConfiguration};
 use core::slice::{Iter, IterMut};
@@ -8,44 +17,55 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Index, IndexMut};
 use std::{thread, time};
 
+// Dummy data struct. Simply uses a u32 for instantiation.
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Data(pub u32);
+// Dummy ID, also uses a u32 for instantiation.
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Id(pub u32);
 
+// Allows a usize to be used for Id struct creation.
 impl From<usize> for Id {
     fn from(x: usize) -> Id {
         Id(x as u32)
     }
 }
 
+// Allows a usize to be used for Data struct creation.
 impl From<usize> for Data {
     fn from(x: usize) -> Data {
         Data(x as u32)
     }
 }
 
+// A simple struct for holding peer information, This includes both an id and an address.
 pub struct TestPeer<Id> {
     pub id: Id,
     pub net_addr: String,
 }
 
+// Implement the Peer trait for TestPeer.
 impl Peer<Id> for TestPeer<Id> {
+    // Create a new peer
     fn new(id: Id, addr: String) -> TestPeer<Id> {
         TestPeer { id, net_addr: addr }
     }
+    // Getter for the Id
     fn get_id(&self) -> Id {
         self.id.clone()
     }
+    // Getter for the inputted address
     fn get_net_addr(&self) -> String {
         self.net_addr.clone()
     }
 }
 
+// Creation of our own PeerList type.
 pub struct TestPeerList<Id> {
     peers: Vec<TestPeer<Id>>,
 }
 
+// Allows the use of indexing to access data within the peer list.
 impl<Id> Index<usize> for TestPeerList<Id> {
     type Output = TestPeer<Id>;
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,38 +73,57 @@ impl<Id> Index<usize> for TestPeerList<Id> {
     }
 }
 
+// Allows the use of indexing to access mutable data within the peer list.
 impl<Id> IndexMut<usize> for TestPeerList<Id> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.peers[index]
     }
 }
 
+// Implementation of PeerList for our TestPeerList struct.
 impl PeerList<Id, Error> for TestPeerList<Id> {
+
     type P = TestPeer<Id>;
+
+    // Constructor
     fn new() -> Self {
         TestPeerList {
             peers: Vec::with_capacity(1),
         }
     }
+    // Function which allows addimng new peers to our peer list.
     fn add(&mut self, p: TestPeer<Id>) -> std::result::Result<(), Error> {
+        // Check if we're at max capacity
         if self.peers.len() == std::usize::MAX {
             return Err(AtMaxVecCapacity);
         }
+        // Push value into vec
         self.peers.push(p);
+
         Ok(())
     }
+    // Loads peers in from a json file. Not relevant to this test.
     fn get_peers_from_file(&mut self, _json_peer_path: String) -> std::result::Result<(), Error> {
         // Stub not used in tests to satisfy PeerList trait
         Ok(())
     }
+    // Allows iteration over the file.
     fn iter(&self) -> Iter<'_, Self::P> {
         self.peers.iter()
     }
+    // Allows a mutable iteration over the file.
     fn iter_mut(&mut self) -> IterMut<'_, Self::P> {
         self.peers.iter_mut()
     }
 }
 
+/*
+    The function used to actually test the Transport. It takes in a Transport Configuration and a
+    Transport trait implementor.
+
+    THis method simply takes in a list of peers, instantiates them, and tests whether they can
+    send/receive data to one another.
+*/
 pub fn common_test<
     C: TransportConfiguration<Data>,
     T: Transport<Id, Data, Error, TestPeerList<Id>, C>,
@@ -92,21 +131,31 @@ pub fn common_test<
     net_addrs: Vec<String>,
 ) {
     let n_peers = net_addrs.len();
+    // Create a new TestPeerList
     let mut pl: TestPeerList<Id> = TestPeerList::new();
+
     let mut trns: Vec<T> = Vec::with_capacity(n_peers);
+    // Iterate over all peers, create a config for each one and create a Transport to handle
+    // messaging.
     for i in 0..n_peers {
         let config = C::new(net_addrs[i].clone()).unwrap();
         pl.add(TestPeer::new(i.into(), net_addrs[i].clone()))
             .unwrap();
         trns.push(T::new(config));
     }
+
+    // Wait three seconds.
     thread::sleep(time::Duration::from_secs(3));
 
     // Test broadcast
     println!("Broadcast test");
+
+    // Create Data to send.
     let d: Data = Data(55);
+    // Broadcast data.
     trns[0].broadcast(&mut pl, d.clone()).unwrap();
     for i in 0..n_peers {
+        // Asynchronously check if all peers have received the message.
         block_on(async {
             println!("receiving from peer {}", i);
             let n = trns[i].next().await;
@@ -120,7 +169,9 @@ pub fn common_test<
     // Test direct sending
     println!("Unicast test");
     let u: Data = Data(0xaa);
+    // Send directed data between two peers.
     trns[1].send(pl[0].net_addr.clone(), u.clone()).unwrap();
+    // Asynchronously check whether the receiver got the sent message.
     block_on(async {
         let n = trns[0].next().await;
         match n {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,11 @@
 /// The Transport trait defines the functionality for connecting with other devices in the same
 /// network. This trait will handle the barebones methods of:
 ///
-/// a) Creating a set of peers
-/// b) Sending data between multiple peers
-/// c) Broadcasting messages to all peers within the same network.
+/// a) Recieving data from a peer
+/// b) Sending data to a peer
+/// c) Broadcasting messages to all peers in the peerslist
 ///
-/// The Transport trait requires the definition of a number of types to work properly:
+/// The Transport trait requires the following parameter types to work properly:
 ///
 /// Id: The unqiue ID type of the peer in question. This can be as simple as:
 /// ```
@@ -45,7 +45,9 @@
 /// https://github.com/Fantom-foundation/libcommon-rs )
 /// <b>Configuration:</b> The TransportConfiguration type required to make the function work.
 ///
-/// Finally, the Transport trait implements three methods: 'new', 'send', and 'broadcast'
+/// Finally, the Transport trait implements three methods: 'new', 'send', and 'broadcast'. The trait
+/// also requires an implementation of the 'Stream' trait from the async/.await framework (only
+/// available on nightly).
 ///
 /// For further examples on how you can use the Transport trait, please look at the 'generic_test.rs'
 /// file for a simple implementation.
@@ -112,7 +114,6 @@ pub enum TransportType {
 /// }
 /// ```
 pub trait TransportConfiguration<Data> {
-
     /// Creates a new configuration with a specified network, taking the address of the incoming
     /// messages listener.
     /// Requires a network address as a String.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,55 @@
+/// # Fantom libtransport
+///
+/// This library defines a trait for the management and definition of specific transport prototcols
+/// (such as TCP/IP or UDP). This repository solely defines the trait and provides no further
+/// functionality. If you want a specific implementation, please check the transport-tcp repo for a
+/// complete implementation: https://github.com/Fantom-foundation/libtransport-tcp.
+///
+/// Currently, two traits are defined: TransportConfiguration and Transport.
+///
+/// # TransportConfiguration
+///
+/// Currently the TransportConfiguration trait requires the definition of a type: Data. Data can
+/// be of any type which needs to be transmitted across the network. An example of a 'Data'
+/// definition can be:
+///
+/// ```
+/// // An arbritrary data type which should be transmitted across the network
+/// pub struct Data(pub u32);
+///
+/// ```
+/// This trait also comes with two functions which need to be implemented: 'new' and
+/// 'set_bind_net_addr'. These will be addressed below.
+///
+/// A transport configuration is essential for the Transport trait to function properly.
+///
+/// # Transport
+///
+/// The Transport trait defines the functionality for connecting with other devices in the same
+/// network. This trait will handle the barebones methods of:
+///
+/// a) Creating a set of peers
+/// b) Sending data between multiple peers
+/// c) Broadcasting messages to all peers within the same network.
+///
+/// The Transport trait requires the definition of a number of types to work properly:
+///
+/// Id: The unqiue ID type of the peer in question. This can be as simple as:
+/// ```
+/// // Another arbitrary type for holding ID data
+/// pub struct Id(pub u32);
+/// ```
+/// <b>Data:</b> The data being transmitted between peers - same as the data struct defined above.
+/// <b>Error:</b> An error type that can be returned by the methods in PeerList
+/// <b>Pl:</b> A struct which implementes the PeerList trait (defined in the libcommon repo:
+/// https://github.com/Fantom-foundation/libcommon-rs )
+/// <b>Configuration:</b> The TransportConfiguration type required to make the function work.
+///
+/// Finally, the Transport trait implements three methods: 'new', 'send', and 'broadcast'
+///
+/// For further examples on how you can use the Transport trait, please look at the 'generic_test.rs'
+/// file for a simple implementation.
+
 use crate::errors::Result;
 use futures::stream::Stream;
 use libcommon_rs::peer::{PeerId, PeerList};
@@ -10,7 +62,7 @@ pub enum TransportType {
     TCP,
 }
 
-// Transport configurtatiion trait
+// Transport configuration trait
 pub trait TransportConfiguration<Data> {
     // creates new transport configuration with specified network
     // address for incoming messages listener
@@ -30,7 +82,7 @@ pub trait TransportConfiguration<Data> {
 // Id - peer ID type
 // Data - Transmitting data type;
 // Error - error type returned by methods of Pl: PeerList
-// it can be a truct containing message type and payload data
+// it can be a struct containing message type and payload data
 pub trait Transport<Id, Data, Error, Pl>: Stream<Item = Data> + Drop + Unpin
 where
     Id: PeerId,


### PR DESCRIPTION
Added a bunch of comments to try and explain on a general level how the transport works. Where examples were a little too complex, I decided to refer people to libtransport-tcp, since it has more solid examples of how this trait can be implemented effectively. 

Let me know if I interpreted the code correctly/used the conventions right. 